### PR TITLE
refactor: BenchGallery修复 还有当时论文做实验时候设置的阈值同步修改

### DIFF
--- a/one-eval-web/src/pages/Gallery.tsx
+++ b/one-eval-web/src/pages/Gallery.tsx
@@ -15,6 +15,10 @@ import {
   RefreshCw,
   Loader2,
   Plus,
+  Bot,
+  MessageSquare,
+  FlaskConical,
+  FileSearch,
 } from "lucide-react";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -26,7 +30,7 @@ import { cn } from "@/lib/utils";
 // Types - 匹配 bench_gallery.json 的数据结构
 // ============================================================================
 
-type BenchCategory = "Math" | "Reasoning" | "Knowledge" | "Safety" | "Coding" | "General";
+type BenchCategory = "Math" | "Reasoning" | "Knowledge & QA" | "Safety & Alignment" | "Coding" | "Agents & Tools" | "Instruction & Chat" | "Long Context & RAG" | "Domain-Specific";
 
 // bench_gallery.json 中的 HF 元数据
 type HfMeta = {
@@ -101,7 +105,6 @@ type BenchItem = {
     category: BenchCategory;
     tags: string[];
     description: string;
-    sampleCount?: number;
     datasetUrl?: string;
     datasetKeys?: string[];
   };
@@ -115,12 +118,15 @@ type BenchItem = {
 
 const CATEGORIES: Array<{ id: BenchCategory | "All"; label: string }> = [
   { id: "All", label: "All" },
-  { id: "Math", label: "Math" },
+  { id: "Knowledge & QA", label: "Knowledge & QA" },
   { id: "Reasoning", label: "Reasoning" },
-  { id: "Knowledge", label: "Knowledge" },
-  { id: "Safety", label: "Safety" },
+  { id: "Math", label: "Math" },
   { id: "Coding", label: "Coding" },
-  { id: "General", label: "General" },
+  { id: "Long Context & RAG", label: "Long Context & RAG" },
+  { id: "Instruction & Chat", label: "Instruction & Chat" },
+  { id: "Agents & Tools", label: "Agents & Tools" },
+  { id: "Safety & Alignment", label: "Safety & Alignment" },
+  { id: "Domain-Specific", label: "Domain-Specific" },
 ];
 
 // ============================================================================
@@ -133,12 +139,20 @@ function getBenchIcon(category: BenchCategory) {
       return { Icon: BookOpen, bg: "bg-emerald-50", fg: "text-emerald-600" };
     case "Reasoning":
       return { Icon: Brain, bg: "bg-indigo-50", fg: "text-indigo-600" };
-    case "Knowledge":
+    case "Knowledge & QA":
       return { Icon: GraduationCap, bg: "bg-sky-50", fg: "text-sky-600" };
-    case "Safety":
+    case "Safety & Alignment":
       return { Icon: ShieldCheck, bg: "bg-amber-50", fg: "text-amber-700" };
     case "Coding":
       return { Icon: Code2, bg: "bg-violet-50", fg: "text-violet-600" };
+    case "Agents & Tools":
+      return { Icon: Bot, bg: "bg-rose-50", fg: "text-rose-600" };
+    case "Instruction & Chat":
+      return { Icon: MessageSquare, bg: "bg-pink-50", fg: "text-pink-600" };
+    case "Long Context & RAG":
+      return { Icon: FileSearch, bg: "bg-cyan-50", fg: "text-cyan-600" };
+    case "Domain-Specific":
+      return { Icon: FlaskConical, bg: "bg-orange-50", fg: "text-orange-600" };
     default:
       return { Icon: Tag, bg: "bg-slate-50", fg: "text-slate-600" };
   }
@@ -156,7 +170,7 @@ function transformBenchGalleryItem(item: BenchGalleryItem): BenchItem {
     id: item.bench_name,
     name: displayName,
     meta: {
-      category: meta.category || "General",
+      category: meta.category || "Knowledge & QA",
       tags: meta.tags || [],
       description: meta.description || "",
       datasetUrl: item.bench_source_url,
@@ -190,16 +204,20 @@ function saveGalleryBenches(items: BenchItem[]) {
 // Component
 // ============================================================================
 
-// Bench 类型选项
+// Bench 类型选项（对应新分类）
 const BENCH_TYPES = [
-  "language & reasoning",
-  "safety",
-  "code",
-  "math",
   "knowledge",
+  "language & reasoning",
+  "math",
+  "coding",
   "information retrieval & RAG",
+  "instruction-following",
+  "conversation & chatbots",
   "agents & tools use",
-  "multimodal",
+  "safety",
+  "bias & ethics",
+  "domain-specific",
+  "multilingual",
   "other",
 ];
 
@@ -217,7 +235,7 @@ export const Gallery = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [addForm, setAddForm] = useState({
     bench_name: "",
-    type: "language & reasoning",
+    type: "knowledge",
     description: "",
     dataset_url: "",
   });
@@ -315,7 +333,7 @@ export const Gallery = () => {
       // 成功后刷新列表并关闭弹窗
       await fetchBenches();
       setIsAddModalOpen(false);
-      setAddForm({ bench_name: "", type: "language & reasoning", description: "", dataset_url: "" });
+      setAddForm({ bench_name: "", type: "knowledge", description: "", dataset_url: "" });
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to add bench");
     } finally {
@@ -420,11 +438,6 @@ export const Gallery = () => {
                           <div className="text-xs text-slate-500 mt-0.5">{bench.meta.category}</div>
                         </div>
                       </div>
-                      {bench.meta.sampleCount != null && (
-                        <div className="px-2 py-1 bg-slate-50 border border-slate-200 rounded text-xs font-mono text-slate-500">
-                          {bench.meta.sampleCount.toLocaleString()} samples
-                        </div>
-                      )}
                     </div>
 
                     <div className="flex flex-wrap gap-2 mt-4">
@@ -557,24 +570,6 @@ export const Gallery = () => {
                             .split(",")
                             .map((t) => t.trim())
                             .filter(Boolean),
-                        },
-                      })
-                    }
-                    className="border-slate-200"
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label>Sample Count</Label>
-                  <Input
-                    type="number"
-                    value={activeBench.meta.sampleCount ?? ""}
-                    onChange={(e) =>
-                      handleUpdateBench({
-                        ...activeBench,
-                        meta: {
-                          ...activeBench.meta,
-                          sampleCount: e.target.value ? Number(e.target.value) : undefined,
                         },
                       })
                     }

--- a/one_eval/nodes/bench_name_suggest_node.py
+++ b/one_eval/nodes/bench_name_suggest_node.py
@@ -471,6 +471,10 @@ class BenchNameSuggestNode(BaseNode):
         # 如果已经是 repo ID 格式，直接返回
         return url
 
+    # 质量阈值：低于此分数的本地结果视为不够匹配
+    SCORE_THRESHOLD_TFIDF = 0.3
+    SCORE_THRESHOLD_RAG = 0.5
+
     async def run(self, state: NodeState) -> NodeState:
         """
         执行 benchmark 检索推荐
@@ -478,7 +482,7 @@ class BenchNameSuggestNode(BaseNode):
         流程：
         1. 从 state 中提取查询信息
         2. 使用 BenchmarkRetriever 检索（RAG 或 TF-IDF）
-        3. 返回 top_k 个结果，设置 skip_resolve=True 跳过后续 HF 解析
+        3. 按分数阈值过滤，高质量结果保留；不足时交由 BenchResolveAgent 上 HF 补充
         """
         info = self._extract_query_info(state)
 
@@ -507,9 +511,13 @@ class BenchNameSuggestNode(BaseNode):
         mode = "RAG" if use_rag else "TF-IDF"
         log.info(f"[{mode}模式] 检索到 {len(search_results)} 个 benchmark")
 
+        # 按分数阈值区分高质量 / 低质量结果
+        score_threshold = self.SCORE_THRESHOLD_RAG if use_rag else self.SCORE_THRESHOLD_TFIDF
+
         # 转换检索结果
         bench_info: Dict[str, Dict[str, Any]] = {}
         local_matches = []
+        quality_matches = []  # 高于阈值的结果
 
         for result in search_results:
             name = result.get('name', '')
@@ -519,41 +527,79 @@ class BenchNameSuggestNode(BaseNode):
 
             # 从 URL 提取 HF repo ID（用于下载）
             hf_repo_id = self._extract_hf_repo_from_url(dataset_url) or name
+            score = result.get('score', 0.0)
 
             bench_data = {
                 'bench_name': hf_repo_id,  # 使用完整 repo ID
                 'type': result.get('type', ''),
                 'description': result.get('description', ''),
                 'dataset_url': dataset_url,
-                'score': result.get('score', 0.0),
+                'score': score,
                 'source': 'retrieval',
             }
             bench_info[hf_repo_id] = bench_data
             local_matches.append(bench_data)
+            if score >= score_threshold:
+                quality_matches.append(bench_data)
 
-        # 构建 BenchInfo 列表
+        # 构建 BenchInfo 列表（只保留高质量本地结果）
         state.benches = [
             BenchInfo(
-                bench_name=repo_id,  # 使用完整 HF repo ID
+                bench_name=repo_id,
                 bench_table_exist=True,
                 bench_source_url=bench_info[repo_id].get('dataset_url'),
                 meta=bench_info[repo_id],
             )
             for repo_id in bench_info.keys()
+            if bench_info[repo_id].get('score', 0.0) >= score_threshold
         ]
 
-        state.bench_info = bench_info
+        state.bench_info = {
+            repo_id: data for repo_id, data in bench_info.items()
+            if data.get('score', 0.0) >= score_threshold
+        }
+
+        # 判断是否需要 BenchResolveAgent 去 HF 补充搜索
+        specific_benches: List[str] = info.get("specific_benches") or []
+        need_hf_resolve = len(quality_matches) < self.top_k or len(specific_benches) > 0
+
+        # 收集需要在 HF 上搜索的名称
+        names_for_hf: List[str] = []
+        if need_hf_resolve:
+            matched_names = {m['bench_name'] for m in quality_matches}
+            # 1) 用户明确指定的 benchmark 且本地没有高质量匹配的
+            for name in specific_benches:
+                if name and name not in matched_names:
+                    names_for_hf.append(name)
+            # 2) 本地低分结果的名字也交给 HF 搜索，作为候选补充
+            if len(quality_matches) < self.top_k:
+                for m in local_matches:
+                    if m['bench_name'] not in matched_names and m['bench_name'] not in names_for_hf:
+                        names_for_hf.append(m['bench_name'])
+
+        skip_resolve = not need_hf_resolve
+
+        state.temp_data["skip_resolve"] = skip_resolve
+        state.temp_data["bench_names_suggested"] = names_for_hf
 
         state.agent_results["BenchNameSuggestNode"] = {
             "local_matches": local_matches,
-            "bench_names": [],
-            "skip_resolve": True,
+            "quality_matches": [m['bench_name'] for m in quality_matches],
+            "bench_names": names_for_hf,
+            "skip_resolve": skip_resolve,
             "retrieval_mode": "rag" if use_rag else "tfidf",
             "search_query": search_query,
+            "score_threshold": score_threshold,
         }
 
-        # 跳过后续 BenchResolveAgent
-        state.temp_data["skip_resolve"] = True
+        if skip_resolve:
+            log.info(f"检索完成，{len(quality_matches)} 个高质量结果，跳过 HF 搜索")
+        else:
+            log.info(
+                f"检索完成，{len(quality_matches)}/{self.top_k} 个高质量结果 "
+                f"(阈值 {score_threshold})，将由 BenchResolveAgent 补充 HF 搜索"
+            )
+            if names_for_hf:
+                log.info(f"待 HF 搜索的名称: {names_for_hf}")
 
-        log.info(f"检索完成，返回 {len(local_matches)} 个 benchmark")
         return state

--- a/one_eval/utils/bench_table/bench_gallery.json
+++ b/one_eval/utils/bench_table/bench_gallery.json
@@ -21,7 +21,7 @@
           "crmarena",
           "CRMArena"
         ],
-        "category": "General",
+        "category": "Agents & Tools",
         "tags": [
           "agents & tools use"
         ],
@@ -98,7 +98,7 @@
           "crmarena-pro",
           "CRMArena-Pro"
         ],
-        "category": "General",
+        "category": "Agents & Tools",
         "tags": [
           "agents & tools use"
         ],
@@ -197,7 +197,7 @@
           "gaia",
           "GAIA"
         ],
-        "category": "General",
+        "category": "Agents & Tools",
         "tags": [
           "agents & tools use"
         ],
@@ -307,7 +307,7 @@
           "scigym",
           "SciGym"
         ],
-        "category": "General",
+        "category": "Agents & Tools",
         "tags": [
           "agents & tools use",
           "domain-specific"
@@ -373,10 +373,9 @@
           "acpbench",
           "ACPBench"
         ],
-        "category": "Reasoning",
+        "category": "Agents & Tools",
         "tags": [
-          "agents & tools use",
-          "language & reasoning"
+          "agents & tools use"
         ],
         "description": "A benchmark for evaluating the reasoning tasks in the field of planning. The benchmark consists of 7 reasoning tasks over 13 planning domains.",
         "hf_meta": {
@@ -384,8 +383,7 @@
           "hf_repo": "ibm-research/acp_bench",
           "card_text": "A benchmark for evaluating the reasoning tasks in the field of planning. The benchmark consists of 7 reasoning tasks over 13 planning domains.",
           "tags": [
-            "agents & tools use",
-            "language & reasoning"
+            "agents & tools use"
           ],
           "exists_on_hf": true
         },
@@ -750,7 +748,7 @@
           "global-mmlu",
           "Global MMLU"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
           "bias & ethics"
         ],
@@ -1402,7 +1400,7 @@
           "civil-comments",
           "Civil Comments"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
           "bias & ethics"
         ],
@@ -2045,7 +2043,7 @@
           "wildchat",
           "WildChat"
         ],
-        "category": "General",
+        "category": "Instruction & Chat",
         "tags": [
           "conversation & chatbots"
         ],
@@ -2110,7 +2108,7 @@
           "mixeval",
           "MixEval"
         ],
-        "category": "General",
+        "category": "Instruction & Chat",
         "tags": [
           "conversation & chatbots"
         ],
@@ -2197,7 +2195,7 @@
           "mt-bench",
           "MT-Bench"
         ],
-        "category": "General",
+        "category": "Instruction & Chat",
         "tags": [
           "conversation & chatbots"
         ],
@@ -2270,7 +2268,7 @@
           "wildbench",
           "Wildbench"
         ],
-        "category": "General",
+        "category": "Instruction & Chat",
         "tags": [
           "conversation & chatbots"
         ],
@@ -2357,7 +2355,7 @@
           "lab-bench-language-agent-biology-benchmark",
           "LAB-Bench (Language Agent Biology Benchmark)"
         ],
-        "category": "General",
+        "category": "Domain-Specific",
         "tags": [
           "domain-specific"
         ],
@@ -2493,7 +2491,7 @@
           "cupcase",
           "CUPCase"
         ],
-        "category": "General",
+        "category": "Domain-Specific",
         "tags": [
           "domain-specific"
         ],
@@ -2568,7 +2566,7 @@
           "medconceptsqa",
           "MedConceptsQA"
         ],
-        "category": "General",
+        "category": "Domain-Specific",
         "tags": [
           "domain-specific"
         ],
@@ -2850,8 +2848,9 @@
           "eq-bench",
           "EQ-Bench"
         ],
-        "category": "General",
+        "category": "Instruction & Chat",
         "tags": [
+          "conversation & chatbots",
           "empathy"
         ],
         "description": "Assesses the ability of LLMs to understand complex emotions and social interactions by asking them to predict the intensity of emotional states of characters in a dialogue.",
@@ -2860,6 +2859,7 @@
           "hf_repo": "pbevan11/EQ-Bench",
           "card_text": "Assesses the ability of LLMs to understand complex emotions and social interactions by asking them to predict the intensity of emotional states of characters in a dialogue.",
           "tags": [
+            "conversation & chatbots",
             "empathy"
           ],
           "exists_on_hf": true
@@ -2914,7 +2914,7 @@
           "wice",
           "WiCE"
         ],
-        "category": "General",
+        "category": "Long Context & RAG",
         "tags": [
           "information retrieval & RAG"
         ],
@@ -2990,7 +2990,7 @@
           "contextualbench",
           "ContextualBench"
         ],
-        "category": "General",
+        "category": "Long Context & RAG",
         "tags": [
           "information retrieval & RAG"
         ],
@@ -3119,7 +3119,7 @@
           "nolima",
           "NoLiMa"
         ],
-        "category": "General",
+        "category": "Long Context & RAG",
         "tags": [
           "information retrieval & RAG"
         ],
@@ -3180,7 +3180,7 @@
           "wixqa",
           "WixQA"
         ],
-        "category": "General",
+        "category": "Long Context & RAG",
         "tags": [
           "information retrieval & RAG"
         ],
@@ -3285,11 +3285,10 @@
           "frames-factuality-retrieval-and-reasoning-measurement-set",
           "FRAMES (Factuality, Retrieval, And reasoning MEasurement Set)"
         ],
-        "category": "Safety",
+        "category": "Long Context & RAG",
         "tags": [
           "information retrieval & RAG",
-          "language & reasoning",
-          "safety"
+          "language & reasoning"
         ],
         "description": "Tests the capabilities of Retrieval-Augmented Generation (RAG) systems across factuality, retrieval accuracy, and reasoning.",
         "hf_meta": {
@@ -3298,8 +3297,7 @@
           "card_text": "Tests the capabilities of Retrieval-Augmented Generation (RAG) systems across factuality, retrieval accuracy, and reasoning.",
           "tags": [
             "information retrieval & RAG",
-            "language & reasoning",
-            "safety"
+            "language & reasoning"
           ],
           "exists_on_hf": true
         },
@@ -3359,10 +3357,9 @@
           "ragtruth",
           "RAGTruth"
         ],
-        "category": "Safety",
+        "category": "Long Context & RAG",
         "tags": [
-          "information retrieval & RAG",
-          "safety"
+          "information retrieval & RAG"
         ],
         "description": "A corpus tailored for analyzing word-level hallucinations within the standard RAG frameworks for LLM applications. RAGTruth comprises 18,000 naturally generated responses from diverse LLMs using RAG.",
         "hf_meta": {
@@ -3370,8 +3367,7 @@
           "hf_repo": "wandb/RAGTruth-processed",
           "card_text": "A corpus tailored for analyzing word-level hallucinations within the standard RAG frameworks for LLM applications. RAGTruth comprises 18,000 naturally generated responses from diverse LLMs using RAG.",
           "tags": [
-            "information retrieval & RAG",
-            "safety"
+            "information retrieval & RAG"
           ],
           "exists_on_hf": true
         },
@@ -3432,7 +3428,7 @@
           "infobench",
           "Infobench"
         ],
-        "category": "General",
+        "category": "Instruction & Chat",
         "tags": [
           "instruction-following"
         ],
@@ -3498,10 +3494,10 @@
           "megascience",
           "MegaScience"
         ],
-        "category": "Knowledge",
+        "category": "Knowledge & QA",
         "tags": [
           "knowledge",
-          "language & reasoning"
+          "domain-specific"
         ],
         "description": "A large-scale mixture of high-quality open-source datasets totaling 1.25 million instances.",
         "hf_meta": {
@@ -3510,7 +3506,7 @@
           "card_text": "A large-scale mixture of high-quality open-source datasets totaling 1.25 million instances.",
           "tags": [
             "knowledge",
-            "language & reasoning"
+            "domain-specific"
           ],
           "exists_on_hf": true
         },
@@ -3564,10 +3560,9 @@
           "mmlu",
           "MMLU"
         ],
-        "category": "Knowledge",
+        "category": "Knowledge & QA",
         "tags": [
-          "knowledge",
-          "language & reasoning"
+          "knowledge"
         ],
         "description": "Multi-choice tasks across 57 subjects, high school to expert level.",
         "hf_meta": {
@@ -3575,8 +3570,7 @@
           "hf_repo": "cais/mmlu",
           "card_text": "Multi-choice tasks across 57 subjects, high school to expert level.",
           "tags": [
-            "knowledge",
-            "language & reasoning"
+            "knowledge"
           ],
           "exists_on_hf": true
         },
@@ -4678,10 +4672,9 @@
           "arc",
           "ARC"
         ],
-        "category": "Knowledge",
+        "category": "Knowledge & QA",
         "tags": [
-          "knowledge",
-          "language & reasoning"
+          "knowledge"
         ],
         "description": "Grade-school level, multiple-choice science questions.",
         "hf_meta": {
@@ -4689,8 +4682,7 @@
           "hf_repo": "allenai/ai2_arc",
           "card_text": "Grade-school level, multiple-choice science questions.",
           "tags": [
-            "knowledge",
-            "language & reasoning"
+            "knowledge"
           ],
           "exists_on_hf": true
         },
@@ -4774,10 +4766,9 @@
           "mmlu-pro",
           "MMLU Pro"
         ],
-        "category": "Knowledge",
+        "category": "Knowledge & QA",
         "tags": [
-          "knowledge",
-          "language & reasoning"
+          "knowledge"
         ],
         "description": "An enhanced dataset designed to extend the MMLU benchmark. More challenging questions, the choice set of ten options.",
         "hf_meta": {
@@ -4785,8 +4776,7 @@
           "hf_repo": "TIGER-Lab/MMLU-Pro",
           "card_text": "An enhanced dataset designed to extend the MMLU benchmark. More challenging questions, the choice set of ten options.",
           "tags": [
-            "knowledge",
-            "language & reasoning"
+            "knowledge"
           ],
           "exists_on_hf": true
         },
@@ -4842,10 +4832,9 @@
           "truthfulqa",
           "TruthfulQA"
         ],
-        "category": "Safety",
+        "category": "Knowledge & QA",
         "tags": [
           "knowledge",
-          "language & reasoning",
           "safety"
         ],
         "description": "Evaluates how well models generate truthful responses.",
@@ -4855,7 +4844,6 @@
           "card_text": "Evaluates how well models generate truthful responses.",
           "tags": [
             "knowledge",
-            "language & reasoning",
             "safety"
           ],
           "exists_on_hf": true
@@ -5567,9 +5555,9 @@
           "squad-stanford-question-answering-dataset",
           "SQuAD (Stanford Question Answering Dataset)"
         ],
-        "category": "Reasoning",
+        "category": "Long Context & RAG",
         "tags": [
-          "language & reasoning"
+          "information retrieval & RAG"
         ],
         "description": "A reading comprehension dataset consisting of 100,000 questions posed by crowdworkers on a set of Wikipedia articles.",
         "hf_meta": {
@@ -5577,7 +5565,7 @@
           "hf_repo": "rajpurkar/squad",
           "card_text": "A reading comprehension dataset consisting of 100,000 questions posed by crowdworkers on a set of Wikipedia articles.",
           "tags": [
-            "language & reasoning"
+            "information retrieval & RAG"
           ],
           "exists_on_hf": true
         },
@@ -5635,9 +5623,9 @@
           "openbookqa",
           "OpenBookQA"
         ],
-        "category": "Reasoning",
+        "category": "Knowledge & QA",
         "tags": [
-          "language & reasoning"
+          "knowledge"
         ],
         "description": "Question answering dataset, modeled after open book exams.",
         "hf_meta": {
@@ -5645,7 +5633,7 @@
           "hf_repo": "allenai/openbookqa",
           "card_text": "Question answering dataset, modeled after open book exams.",
           "tags": [
-            "language & reasoning"
+            "knowledge"
           ],
           "exists_on_hf": true
         },
@@ -5723,9 +5711,9 @@
           "squad2-0",
           "SQuAD2.0"
         ],
-        "category": "Reasoning",
+        "category": "Long Context & RAG",
         "tags": [
-          "language & reasoning"
+          "information retrieval & RAG"
         ],
         "description": "Combines the 100,000 questions in SQuAD1.1 with over 50,000 unanswerable questions written adversarially by crowdworkers to look similar to answerable ones.",
         "hf_meta": {
@@ -5733,7 +5721,7 @@
           "hf_repo": "bayes-group-diffusion/squad-2.0",
           "card_text": "Combines the 100,000 questions in SQuAD1.1 with over 50,000 unanswerable questions written adversarially by crowdworkers to look similar to answerable ones.",
           "tags": [
-            "language & reasoning"
+            "information retrieval & RAG"
           ],
           "exists_on_hf": true
         },
@@ -5796,9 +5784,9 @@
           "ms-marco",
           "MS MARCO"
         ],
-        "category": "Reasoning",
+        "category": "Long Context & RAG",
         "tags": [
-          "language & reasoning"
+          "information retrieval & RAG"
         ],
         "description": "Questions sampled from Bing's search query logs and passages from web documents.",
         "hf_meta": {
@@ -5806,7 +5794,7 @@
           "hf_repo": "microsoft/ms_marco",
           "card_text": "Questions sampled from Bing's search query logs and passages from web documents.",
           "tags": [
-            "language & reasoning"
+            "information retrieval & RAG"
           ],
           "exists_on_hf": true
         },
@@ -5883,9 +5871,9 @@
           "sciq",
           "SciQ"
         ],
-        "category": "Reasoning",
+        "category": "Knowledge & QA",
         "tags": [
-          "language & reasoning"
+          "knowledge"
         ],
         "description": "Multiple choice science exam questions.",
         "hf_meta": {
@@ -5893,7 +5881,7 @@
           "hf_repo": "allenai/sciq",
           "card_text": "Multiple choice science exam questions.",
           "tags": [
-            "language & reasoning"
+            "knowledge"
           ],
           "exists_on_hf": true
         },
@@ -5963,9 +5951,9 @@
           "triviaqa",
           "TriviaQA"
         ],
-        "category": "Reasoning",
+        "category": "Knowledge & QA",
         "tags": [
-          "language & reasoning"
+          "knowledge"
         ],
         "description": "A large-scale question-answering dataset.",
         "hf_meta": {
@@ -5973,7 +5961,7 @@
           "hf_repo": "mandarjoshi/trivia_qa",
           "card_text": "A large-scale question-answering dataset.",
           "tags": [
-            "language & reasoning"
+            "knowledge"
           ],
           "exists_on_hf": true
         },
@@ -6685,9 +6673,10 @@
           "longbench",
           "LongBench"
         ],
-        "category": "Reasoning",
+        "category": "Long Context & RAG",
         "tags": [
-          "language & reasoning"
+          "language & reasoning",
+          "information retrieval & RAG"
         ],
         "description": "Assesses the ability of LLMs to handle long-context problems requiring deep understanding and reasoning across real-world multitasks. Consists of multiple-choice questions, with contexts ranging from 8k to 2M words.",
         "hf_meta": {
@@ -6695,7 +6684,8 @@
           "hf_repo": "THUDM/LongBench-v2",
           "card_text": "Assesses the ability of LLMs to handle long-context problems requiring deep understanding and reasoning across real-world multitasks. Consists of multiple-choice questions, with contexts ranging from 8k to 2M words.",
           "tags": [
-            "language & reasoning"
+            "language & reasoning",
+            "information retrieval & RAG"
           ],
           "exists_on_hf": true
         },
@@ -6903,9 +6893,10 @@
           "gpqa",
           "GPQA"
         ],
-        "category": "Reasoning",
+        "category": "Knowledge & QA",
         "tags": [
-          "language & reasoning"
+          "knowledge",
+          "domain-specific"
         ],
         "description": "A set of multiple-choice questions written by domain experts in biology, physics, and chemistry.",
         "hf_meta": {
@@ -6913,7 +6904,8 @@
           "hf_repo": "Idavidrein/gpqa",
           "card_text": "A set of multiple-choice questions written by domain experts in biology, physics, and chemistry.",
           "tags": [
-            "language & reasoning"
+            "knowledge",
+            "domain-specific"
           ],
           "exists_on_hf": true
         },
@@ -7006,12 +6998,10 @@
           "biggen-bench",
           "BiGGen-Bench"
         ],
-        "category": "Safety",
+        "category": "Instruction & Chat",
         "tags": [
-          "language & reasoning",
-          "agents & tools use",
-          "safety",
-          "instruction-following"
+          "instruction-following",
+          "agents & tools use"
         ],
         "description": "Evaluates nine distinct capabilities of LMs, including instruction following, reasoning, tool usage, and safety.",
         "hf_meta": {
@@ -7019,10 +7009,8 @@
           "hf_repo": "prometheus-eval/BiGGen-Bench",
           "card_text": "Evaluates nine distinct capabilities of LMs, including instruction following, reasoning, tool usage, and safety.",
           "tags": [
-            "language & reasoning",
-            "agents & tools use",
-            "safety",
-            "instruction-following"
+            "instruction-following",
+            "agents & tools use"
           ],
           "exists_on_hf": true
         },
@@ -7079,9 +7067,8 @@
           "include",
           "Include"
         ],
-        "category": "Reasoning",
+        "category": "Instruction & Chat",
         "tags": [
-          "language & reasoning",
           "multilingual"
         ],
         "description": "An evaluation suite to measure the capabilities of multilingual LLMs in a variety of regional contexts across 44 written languages.",
@@ -7090,7 +7077,6 @@
           "hf_repo": "CohereLabs/include-base-44",
           "card_text": "An evaluation suite to measure the capabilities of multilingual LLMs in a variety of regional contexts across 44 written languages.",
           "tags": [
-            "language & reasoning",
             "multilingual"
           ],
           "exists_on_hf": true
@@ -7783,9 +7769,8 @@
           "multinrc",
           "MultiNRC"
         ],
-        "category": "Reasoning",
+        "category": "Instruction & Chat",
         "tags": [
-          "language & reasoning",
           "multilingual"
         ],
         "description": "Assesses LLMs on reasoning questions written by native speakers in French, Spanish, and Chinese. MultiNRC covers four core reasoning categories: language-specific linguistic reasoning, wordplay & riddles, cultural/tradition reasoning, and math reasoning with cultural relevance.",
@@ -7794,7 +7779,6 @@
           "hf_repo": "ScaleAI/MultiNRC",
           "card_text": "Assesses LLMs on reasoning questions written by native speakers in French, Spanish, and Chinese. MultiNRC covers four core reasoning categories: language-specific linguistic reasoning, wordplay & riddles, cultural/tradition reasoning, and math reasoning with cultural relevance.",
           "tags": [
-            "language & reasoning",
             "multilingual"
           ],
           "exists_on_hf": true
@@ -7853,7 +7837,7 @@
           "judgebench",
           "JudgeBench"
         ],
-        "category": "General",
+        "category": "Instruction & Chat",
         "tags": [
           "llm judge evaluation"
         ],
@@ -8366,9 +8350,9 @@
           "simpleqa",
           "SimpleQA"
         ],
-        "category": "Safety",
+        "category": "Knowledge & QA",
         "tags": [
-          "safety"
+          "knowledge"
         ],
         "description": "Measures the ability for language models to answer short, fact-seeking questions to reduce hallucinations.",
         "hf_meta": {
@@ -8376,7 +8360,7 @@
           "hf_repo": "basicv8vc/SimpleQA",
           "card_text": "Measures the ability for language models to answer short, fact-seeking questions to reduce hallucinations.",
           "tags": [
-            "safety"
+            "knowledge"
           ],
           "exists_on_hf": true
         },
@@ -8425,7 +8409,7 @@
           "air-bench",
           "AIR-Bench"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
           "safety"
         ],
@@ -8537,7 +8521,7 @@
           "or-bench",
           "OR-Bench"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
           "safety"
         ],
@@ -8624,8 +8608,9 @@
           "agentharm",
           "AgentHarm"
         ],
-        "category": "Safety",
+        "category": "Agents & Tools",
         "tags": [
+          "agents & tools use",
           "safety"
         ],
         "description": "Explicitly malicious agent tasks, including fraud, cybercrime, and harassment.",
@@ -8634,6 +8619,7 @@
           "hf_repo": "ai-safety-institute/AgentHarm",
           "card_text": "Explicitly malicious agent tasks, including fraud, cybercrime, and harassment.",
           "tags": [
+            "agents & tools use",
             "safety"
           ],
           "exists_on_hf": true
@@ -8719,7 +8705,7 @@
           "backdoorllm",
           "BackdoorLLM"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
           "safety"
         ],
@@ -8783,7 +8769,7 @@
           "safetybench",
           "SafetyBench"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
           "safety"
         ],
@@ -8871,7 +8857,7 @@
           "harmfulqa",
           "HarmfulQA"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
           "safety"
         ],
@@ -8936,7 +8922,7 @@
           "beavertails",
           "BeaverTails"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
           "safety"
         ],
@@ -9030,7 +9016,7 @@
           "donotanswer",
           "DoNotAnswer"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
           "safety"
         ],
@@ -9103,7 +9089,7 @@
           "toxigen",
           "ToxiGen"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
           "safety"
         ],
@@ -9317,7 +9303,7 @@
           "anthropicredteam",
           "AnthropicRedTeam"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
           "safety"
         ],
@@ -9386,7 +9372,7 @@
           "realtoxicityprompt",
           "RealToxicityPrompt"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
           "safety"
         ],
@@ -9451,9 +9437,8 @@
           "stereoset",
           "StereoSet"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
-          "safety",
           "bias & ethics"
         ],
         "description": "A large-scale natural dataset in English to measure stereotypical biases in four domains: gender, profession, race, and religion.",
@@ -9462,7 +9447,6 @@
           "hf_repo": "McGill-NLP/stereoset",
           "card_text": "A large-scale natural dataset in English to measure stereotypical biases in four domains: gender, profession, race, and religion.",
           "tags": [
-            "safety",
             "bias & ethics"
           ],
           "exists_on_hf": true
@@ -9532,9 +9516,8 @@
           "winogender",
           "WinoGender"
         ],
-        "category": "Safety",
+        "category": "Safety & Alignment",
         "tags": [
-          "safety",
           "bias & ethics"
         ],
         "description": "Pairs of sentences that differ only by the gender of one pronoun in the sentence, designed to test for the presence of gender bias in automated coreference resolution systems.",
@@ -9543,7 +9526,6 @@
           "hf_repo": "oskarvanderwal/winogender",
           "card_text": "Pairs of sentences that differ only by the gender of one pronoun in the sentence, designed to test for the presence of gender bias in automated coreference resolution systems.",
           "tags": [
-            "safety",
             "bias & ethics"
           ],
           "exists_on_hf": true


### PR DESCRIPTION
BenchGallery修复
还有当时论文做实验时候设置的阈值同步修改

- bench_gallery.json: reclassify 77 benchmarks from 6 to 9 categories (Agents & Tools, Knowledge & QA, Reasoning, Long Context & RAG, Instruction & Chat, Domain-Specific, Safety & Alignment, Math, Coding)
- Gallery.tsx: update BenchCategory type, filter tabs, icons; remove unused sampleCount field
- bench_name_suggest_node.py: add score threshold filtering (TFIDF=0.3, RAG=0.5), route low-quality results to BenchResolveAgent for HF search