### PR TITLE
feat(metrics): add common evaluation metrics

### DIFF
--- a/one-eval-skill/SKILL.md
+++ b/one-eval-skill/SKILL.md
@@ -136,11 +136,11 @@ python scripts/check_model.py --api --model <名> --api-url <url> --api-key <key
 | key1_text_score | ppl（困惑度） | 语言建模流畅度 |
 
 - **主分够用就够用**；但要**主动问用户是否补充维度**，并解释每个维度查什么：
-  正确性（exact_match/numerical_match）、相似度（bleu/rouge_l/chrf/token_f1，翻译摘要长答案）、
-  格式遵循（extraction_rate/format_compliance_score，低分会拖累正确性）、
-  生成健康度（repetition_rate 抓复读）、弃答率（missing_answer_rate 做正确性归因）、
-  代码合法性（code_validity，注意只验能否解析、非逻辑正确）。
-- `python scripts/run_metrics.py --list` 查看全部 14 个 metric（按维度分组，含适用场景）。
+  正确性（exact_match/numerical_match/set_f1，短答案、数值、开放答案集合）、相似度（bleu/rouge_l/chrf/token_f1/jaccard_similarity，翻译摘要长答案/关键词覆盖）、
+  格式遵循（extraction_rate/format_compliance_score/json_validity，低分会拖累正确性或结构化输出可用性）、
+  生成健康度（repetition_rate 抓复读、garbled_text_rate 抓乱码/异常编码）、弃答率与空输出率（missing_answer_rate/empty_or_whitespace_rate 做正确性归因）、
+  代码/SQL 合法性（code_validity / sql_parse_validity，注意只验能否解析、非逻辑正确）。
+- `python scripts/run_metrics.py --list` 查看当前注册表里的全部 metric（按维度分组，含适用场景）。
 - 用户想要注册表里没有的维度 → 参考 `references/metric_registry.md` + `assets/custom_metric.template.py`
   跟用户聊清楚需求后写新 metric，落到 `custom_metrics/`。
 

--- a/one-eval-skill/references/metric_registry.md
+++ b/one-eval-skill/references/metric_registry.md
@@ -25,12 +25,12 @@ logits/跨类别标注。因此需要那类输入的统计指标（AUC-ROC、Pea
 
 | dimension | 衡量什么 | metric |
 |---|---|---|
-| `correctness` | 答案对不对（主结果轴） | exact_match / numerical_match / choice_accuracy / multilabel_f1 / math_verify |
-| `similarity` | 与参考文本的词面相似/重叠（翻译/摘要/长答案） | bleu / rouge_l / chrf / token_f1 |
-| `validity` | 产物本身是否合法可用（≠正确） | code_validity |
-| `fluency` | 生成健康度（退化重复等失败模式） | repetition_rate |
-| `format` | 格式遵循/可抽取性 | extraction_rate / format_compliance_score |
-| `diagnostic` | 纯诊断信号（不直接代表好坏，用于归因） | missing_answer_rate |
+| `correctness` | 答案对不对（主结果轴） | exact_match / numerical_match / choice_accuracy / multilabel_f1 / set_f1 / math_verify |
+| `similarity` | 与参考文本的词面相似/重叠（翻译/摘要/长答案） | bleu / rouge_l / chrf / token_f1 / jaccard_similarity |
+| `validity` | 产物本身是否合法可用（≠正确） | code_validity / sql_parse_validity |
+| `fluency` | 生成健康度（退化重复、乱码/异常编码等失败模式） | repetition_rate / garbled_text_rate |
+| `format` | 格式遵循/可抽取性 | extraction_rate / format_compliance_score / json_validity |
+| `diagnostic` | 纯诊断信号（不直接代表好坏，用于归因） | missing_answer_rate / empty_or_whitespace_rate |
 
 ## 内置 metric 一览
 
@@ -39,19 +39,24 @@ logits/跨类别标注。因此需要那类输入的统计指标（AUC-ROC、Pea
 - `numerical_match` — 数值软匹配（1.0==1，容忍浮点误差，`atol` 可调）
 - `choice_accuracy`（别名 acc / accuracy）— 自动抽取 A/B/C/D 选项准确率
 - `multilabel_f1` — 多标签/多选集合 F1
+- `set_f1` — 开放答案集合 F1，适合列表型 QA、实体抽取、多答案短答
 - `math_verify` — 数学等价性校验（文本匹配 + 符号验证混合）
 
 **similarity**（text_gen.py）
-- `bleu` — sacreBLEU ／ `rouge_l`（别名 rouge）— ROUGE-L F1 ／ `chrf` ／ `token_f1`（别名 f1）
+- `bleu` — sacreBLEU ／ `rouge_l`（别名 rouge）— ROUGE-L F1 ／ `chrf` ／ `token_f1`（别名 f1）／ `jaccard_similarity`（别名 jaccard）— 去重 token 集合重叠，适合关键词覆盖/检索式 QA/事实列表
 
 **validity / fluency**
 - `code_validity`（别名 soft_code_execution）— 代码能否 AST 解析 + 是否定义函数/类。**只验合法性，不代表逻辑正确**；要真 Pass@k 请在受控沙箱自写 custom metric
+- `sql_parse_validity` — SQL 是否能被 parser 解析，适合 Text2SQL/SQL 生成。只验语法/方言可解析性，**不代表执行正确或结果正确**；`dialect` 默认 sqlite，可设 postgres/mysql/bigquery/snowflake 等
 - `repetition_rate` — 退化重复率（1 − distinct-n）。无需 ref，抓“复读机/卡循环”，**分越低越好**（建议作诊断，`n` 可调，默认 3）
+- `garbled_text_rate` — 乱码率。无需 ref，保守检测明显编码损坏；**分越低越好**
 
 **format / diagnostic**
 - `extraction_rate` — 可抽取率（**强烈建议常带上**，诊断是否按格式输出；`extractor` = number/choice/generic）
 - `format_compliance_score` — 答案是否被显式标记出来（boxed/####/答案标记）。+0.5 非空 +0.5 有标记
+- `json_validity` — JSON 合法率；默认要求整段输出可被 `json.loads` 解析，`allow_extraction=True` 时允许从 markdown fenced block 或文本中首个 JSON object/array 提取后解析
 - `missing_answer_rate` — 弃答率（= 1 − 可抽取率）
+- `empty_or_whitespace_rate` — 空输出率：输出为 None、空字符串或纯空白的比例。用于定位服务/生成链路未产出可评内容，**分越低越好**
 
 > **没有确定性指标的两种题型**：纯文本打分（key1_text_score）和偏好对比
 > （key3_q_a_rejected）。后者 runner 只把 better 当 ref 传进来、rejected 取不到，

--- a/one_eval/metrics/common/general.py
+++ b/one_eval/metrics/common/general.py
@@ -3,15 +3,20 @@ general.py —— 通用维度指标:正确性(correctness) + 格式遵循(forma
 
 设计原则:每个指标只服务一个清晰的质量维度,不做参数变体的重复注册。
 - correctness:exact_match / numerical_match / choice_accuracy / multilabel_f1
-- format    :extraction_rate(可抽取性) / format_compliance(答案分隔规范度)
-- diagnostic:missing_answer_rate(弃答率,= 1 - 抽取率,供归因)
+- format    :extraction_rate(可抽取性) / format_compliance(答案分隔规范度) / json_validity
+- diagnostic:missing_answer_rate(弃答率,= 1 - 抽取率,供归因) / empty_or_whitespace_rate
+- fluency   :repetition_rate(退化重复) / garbled_text_rate(乱码/异常编码)
 """
+import json
+import re
+import unicodedata
 from typing import List, Dict, Any, Optional, Set, Tuple
 from one_eval.utils.extractor import (
     normalize_text,
     extract_first_number,
     extract_choice,
     extract_multi_choice,
+    extract_answer_set,
     AnswerExtractor,
 )
 from one_eval.core.metric_registry import register_metric, MetricCategory, MetricDimension
@@ -165,6 +170,47 @@ def compute_multilabel_f1(preds: List[Any], refs: List[Any], **kwargs) -> Dict[s
         scores.append(f1)
     return {"score": sum(scores) / len(scores) if scores else 0.0, "details": scores}
 
+
+@register_metric(
+    name="set_f1",
+    desc="开放答案集合 F1",
+    usage="列表型 QA、实体抽取、多答案短答。将预测与参考解析为开放文本集合后计算 F1",
+    categories=[MetricCategory.QA_SINGLE, MetricCategory.QA_MULTI],
+    dimension=MetricDimension.CORRECTNESS,
+)
+def compute_set_f1(preds: List[Any], refs: List[Any], **kwargs) -> Dict[str, Any]:
+    scores = []
+    artifacts = {"pred_sets": [], "ref_sets": [], "tp": [], "fp": [], "fn": []}
+
+    for p, r in zip(preds, refs):
+        p_set = extract_answer_set(p)
+        r_set = extract_answer_set(r)
+        tp = p_set & r_set
+        fp = p_set - r_set
+        fn = r_set - p_set
+
+        if not p_set and not r_set:
+            f1 = 1.0
+        elif not p_set or not r_set:
+            f1 = 0.0
+        else:
+            prec = len(tp) / (len(tp) + len(fp)) if (tp or fp) else 0.0
+            rec = len(tp) / (len(tp) + len(fn)) if (tp or fn) else 0.0
+            f1 = 2 * prec * rec / (prec + rec) if (prec + rec) > 0 else 0.0
+
+        scores.append(f1)
+        artifacts["pred_sets"].append(sorted(p_set))
+        artifacts["ref_sets"].append(sorted(r_set))
+        artifacts["tp"].append(sorted(tp))
+        artifacts["fp"].append(sorted(fp))
+        artifacts["fn"].append(sorted(fn))
+
+    return {
+        "score": sum(scores) / len(scores) if scores else 0.0,
+        "details": scores,
+        "artifacts": artifacts,
+    }
+
 # __APPEND_FORMAT_DIMENSION__
 
 
@@ -208,6 +254,8 @@ def compute_extraction_rate(preds: List[Any], refs: List[Any], **kwargs) -> Dict
     }
 
 
+# ============================ 诊断维度 ============================
+
 @register_metric(
     name="missing_answer_rate",
     desc="弃答率:未能解析出有效答案的比例 (= 1 - 可抽取率)",
@@ -223,6 +271,36 @@ def compute_missing_answer_rate(preds: List[Any], refs: List[Any], **kwargs) -> 
         "score": 1.0 - result["score"],
         "details": [1.0 - d for d in result["details"]],
         "artifacts": result["artifacts"],
+    }
+
+
+@register_metric(
+    name="empty_or_whitespace_rate",
+    desc="空输出率:输出为 None、空字符串或纯空白的比例",
+    usage="失败归因诊断。低分说明模型/服务根本没有产出可评内容；分越低越好",
+    categories=[
+        MetricCategory.TEXT_SCORE,
+        MetricCategory.QA_SINGLE, MetricCategory.QA_MULTI,
+        MetricCategory.CHOICE_SINGLE, MetricCategory.CHOICE_MULTI,
+        MetricCategory.PAIRWISE,
+    ],
+    dimension=MetricDimension.DIAGNOSTIC,
+)
+def compute_empty_or_whitespace_rate(preds: List[Any], refs: List[Any], **kwargs) -> Dict[str, Any]:
+    """计算空输出/纯空白输出比例。"""
+    details = [1.0 if p is None or str(p).strip() == "" else 0.0 for p in preds]
+    empty_indices = [idx for idx, score in enumerate(details) if score == 1.0]
+
+    total = len(details)
+    empty_count = len(empty_indices)
+    return {
+        "score": empty_count / total if total else 0.0,
+        "details": details,
+        "artifacts": {
+            "empty_count": empty_count,
+            "total": total,
+            "empty_indices": empty_indices,
+        },
     }
 
 
@@ -264,7 +342,165 @@ def compute_format_compliance_score(preds: List[Any], refs: List[Any], **kwargs)
     }
 
 
+def _extract_json_candidate(text: str) -> Tuple[str, bool]:
+    """Return a JSON candidate and whether it was extracted from surrounding text."""
+    s = text.strip()
+    if not s:
+        return s, False
+
+    fenced = re.search(r"```(?:json|JSON)?\s*([\s\S]*?)```", s)
+    if fenced:
+        return fenced.group(1).strip(), True
+
+    decoder = json.JSONDecoder()
+    for idx, ch in enumerate(s):
+        if ch not in "{[":
+            continue
+        try:
+            _, end = decoder.raw_decode(s[idx:])
+        except json.JSONDecodeError:
+            continue
+        return s[idx:idx + end].strip(), idx != 0 or idx + end != len(s)
+
+    return s, False
+
+
+def _parse_json_prediction(pred: Any, allow_extraction: bool) -> Tuple[bool, Dict[str, Any]]:
+    s = "" if pred is None else str(pred).strip()
+    candidate = s
+    extracted = False
+    if allow_extraction:
+        candidate, extracted = _extract_json_candidate(s)
+
+    art: Dict[str, Any] = {
+        "extracted": extracted,
+        "candidate": candidate[:500],
+    }
+    if not candidate:
+        art["error"] = "empty"
+        return False, art
+
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError as e:
+        art["error"] = e.msg
+        art["error_pos"] = e.pos
+        return False, art
+
+    art["parsed_type"] = type(parsed).__name__
+    return True, art
+
+
+@register_metric(
+    name="json_validity",
+    desc="JSON 合法率:输出是否可被 json.loads 解析",
+    usage=(
+        "结构化输出、tool calling、agent 任务、JSON-only 指令。默认严格要求整段输出是 JSON；"
+        "allow_extraction=True 时允许从 markdown fenced block 或周围文本中提取首个 JSON 对象/数组再解析"
+    ),
+    categories=[
+        MetricCategory.TEXT_SCORE,
+        MetricCategory.QA_SINGLE, MetricCategory.QA_MULTI,
+        MetricCategory.CHOICE_SINGLE, MetricCategory.CHOICE_MULTI,
+    ],
+    dimension=MetricDimension.FORMAT,
+)
+def compute_json_validity(preds: List[Any], refs: List[Any], **kwargs) -> Dict[str, Any]:
+    """逐条检查预测是否是合法 JSON。
+
+    kwargs.allow_extraction:
+      False(默认): str(pred).strip() 必须整体可被 json.loads 解析。
+      True: 可从 ```json fenced block``` 或文本中第一个 JSON object/array 提取后解析。
+    """
+    allow_extraction = bool(kwargs.get("allow_extraction", False))
+    parsed = [_parse_json_prediction(p, allow_extraction=allow_extraction) for p in preds]
+    details = [1.0 if ok else 0.0 for ok, _ in parsed]
+
+    return {
+        "score": sum(details) / len(details) if details else 0.0,
+        "details": details,
+        "artifacts": {
+            "allow_extraction": allow_extraction,
+            "items": [art for _, art in parsed],
+        },
+    }
+
+
 # ============================ 流畅度维度 ============================
+
+_ALLOWED_CONTROL_CHARS = {"\n", "\r", "\t"}
+_STRONG_MOJIBAKE_PATTERNS = [
+    "â€™", "â€œ", "â€\x9d", "â€¦", "â€“", "â€”",
+    "ä¸", "ä½", "å›", "å¤", "æ˜", "æœ",
+    "è¿", "è¯", "çš", "ç”", "ï¼", "ï½",
+]
+
+
+def _garbled_reasons(text: str) -> List[str]:
+    reasons = []
+    if "\ufffd" in text:
+        reasons.append("replacement_char")
+
+    for ch in text:
+        code = ord(ch)
+        category = unicodedata.category(ch)
+        if category == "Cc" and ch not in _ALLOWED_CONTROL_CHARS:
+            reasons.append("control_char")
+            break
+        if category == "Cs":
+            reasons.append("surrogate")
+            break
+        if 0xFDD0 <= code <= 0xFDEF or (code & 0xFFFE) == 0xFFFE:
+            reasons.append("noncharacter")
+            break
+
+    if any(pattern in text for pattern in _STRONG_MOJIBAKE_PATTERNS):
+        reasons.append("mojibake")
+
+    return reasons
+
+
+@register_metric(
+    name="garbled_text_rate",
+    desc="乱码率:输出中明显编码损坏/异常 Unicode 的比例",
+    usage="生成健康度,无需 ref。保守检测乱码和异常字符；分越低越好",
+    categories=[
+        MetricCategory.TEXT_SCORE,
+        MetricCategory.QA_SINGLE, MetricCategory.QA_MULTI,
+        MetricCategory.CHOICE_SINGLE, MetricCategory.CHOICE_MULTI,
+        MetricCategory.PAIRWISE,
+    ],
+    dimension=MetricDimension.FLUENCY,
+)
+def compute_garbled_text_rate(preds: List[Any], refs: List[Any], **kwargs) -> Dict[str, Any]:
+    """保守检测乱码/异常编码。空输出记 0,交给 empty_or_whitespace_rate 归因。"""
+    scores, bad_indices, reasons_by_index = [], [], {}
+
+    for idx, p in enumerate(preds):
+        s = "" if p is None else str(p)
+        if not s.strip():
+            scores.append(0.0)
+            continue
+
+        reasons = _garbled_reasons(s)
+        score = 1.0 if reasons else 0.0
+        scores.append(score)
+        if reasons:
+            bad_indices.append(idx)
+            reasons_by_index[str(idx)] = reasons
+
+    garbled_count = int(sum(scores))
+    return {
+        "score": garbled_count / len(scores) if scores else 0.0,
+        "details": scores,
+        "artifacts": {
+            "garbled_count": garbled_count,
+            "total": len(scores),
+            "garbled_indices": bad_indices,
+            "reasons_by_index": reasons_by_index,
+        },
+    }
+
 
 @register_metric(
     name="repetition_rate",

--- a/one_eval/metrics/common/sql.py
+++ b/one_eval/metrics/common/sql.py
@@ -1,0 +1,72 @@
+"""
+sql.py —— Text2SQL / SQL 产物合法性指标。
+
+只做静态 parse，不连接数据库、不检查 schema/table/column，也不代表执行正确。
+"""
+import re
+from typing import List, Any, Dict, Tuple
+
+from one_eval.core.metric_registry import register_metric, MetricCategory, MetricDimension
+
+
+_SQL_FENCE_RE = re.compile(r"```[ \t]*(?:sql|SQL)\s*\n?([\s\S]*?)```")
+_ANY_FENCE_RE = re.compile(r"```[^\n`]*\n?([\s\S]*?)```")
+
+
+def _extract_sql_candidate(pred: Any) -> Tuple[str, bool]:
+    """优先取 markdown SQL 代码块；没有代码块时使用整段输出。"""
+    text = "" if pred is None else str(pred).strip()
+    if not text:
+        return "", False
+
+    match = _SQL_FENCE_RE.search(text) or _ANY_FENCE_RE.search(text)
+    if match:
+        return match.group(1).strip(), True
+    return text, False
+
+
+@register_metric(
+    name="sql_parse_validity",
+    desc="SQL 解析合法率：输出是否能被 SQL parser 解析",
+    usage="Text2SQL、SQL 生成任务。只验 SQL 语法/方言可解析性，不代表执行正确或结果正确；dialect 可设 sqlite/postgres/mysql/bigquery/snowflake 等",
+    categories=[MetricCategory.QA_SINGLE, MetricCategory.QA_MULTI],
+    dimension=MetricDimension.VALIDITY,
+)
+def compute_sql_parse_validity(preds: List[Any], refs: List[Any], **kwargs) -> Dict[str, Any]:
+    """逐条检查预测 SQL 是否可被 sqlglot 解析。
+
+    kwargs.dialect:
+      SQL 方言，默认 sqlite。传空字符串时使用 sqlglot 的通用解析。
+    """
+    import sqlglot
+
+    dialect = str(kwargs.get("dialect", "sqlite") or "").strip() or None
+    scores, artifacts = [], []
+
+    for p in preds:
+        candidate, extracted = _extract_sql_candidate(p)
+        if not candidate:
+            scores.append(0.0)
+            artifacts.append({"valid": False, "error": "empty", "extracted": extracted})
+            continue
+
+        error = None
+        try:
+            valid = bool(sqlglot.parse(candidate, read=dialect))
+        except Exception as e:
+            valid = False
+            error = str(e)
+
+        scores.append(1.0 if valid else 0.0)
+        item = {"valid": valid, "extracted": extracted}
+        if dialect:
+            item["dialect"] = dialect
+        if error:
+            item["error"] = error
+        artifacts.append(item)
+
+    return {
+        "score": sum(scores) / len(scores) if scores else 0.0,
+        "details": scores,
+        "artifacts": artifacts,
+    }

--- a/one_eval/metrics/common/text_gen.py
+++ b/one_eval/metrics/common/text_gen.py
@@ -194,6 +194,34 @@ def compute_token_f1(preds: List[Any], refs: List[Any], **kwargs) -> Dict[str, A
         "details": scores
     }
 
+@register_metric(
+    name="jaccard_similarity",
+    desc="去重 token 集合 Jaccard 相似度",
+    usage="关键词覆盖/检索式 QA/事实列表。只看去重 token 重叠，不看词频与语序",
+    categories=[MetricCategory.QA_SINGLE, MetricCategory.QA_MULTI],
+    dimension=MetricDimension.SIMILARITY,
+    aliases=["jaccard"]
+)
+def compute_jaccard_similarity(preds: List[Any], refs: List[Any], **kwargs) -> Dict[str, Any]:
+    """
+    计算 token 集合 Jaccard similarity: |pred ∩ ref| / |pred ∪ ref|。
+    多参考答案时取最高分，与 token_f1/rouge_l 保持一致。
+    """
+    scores = []
+
+    for p, r in zip(preds, refs):
+        p_str = str(p)
+        r_list = r if isinstance(r, list) else [r]
+        scores.append(max(
+            (_compute_jaccard_single(p_str, str(gold)) for gold in r_list),
+            default=0.0,
+        ))
+
+    return {
+        "score": sum(scores) / len(scores) if scores else 0.0,
+        "details": scores
+    }
+
 def _compute_f1_single(prediction: str, truth: str) -> float:
     from collections import Counter
     pred_tokens = normalize_text(prediction).split()
@@ -210,4 +238,14 @@ def _compute_f1_single(prediction: str, truth: str) -> float:
     precision = num_same / len(pred_tokens)
     recall = num_same / len(truth_tokens)
     return (2 * precision * recall) / (precision + recall)
+
+def _compute_jaccard_single(prediction: str, truth: str) -> float:
+    pred_tokens = set(normalize_text(prediction).split())
+    truth_tokens = set(normalize_text(truth).split())
+
+    if not pred_tokens or not truth_tokens:
+        return 1.0 if pred_tokens == truth_tokens else 0.0
+
+    union = pred_tokens | truth_tokens
+    return len(pred_tokens & truth_tokens) / len(union)
 

--- a/one_eval/utils/extractor.py
+++ b/one_eval/utils/extractor.py
@@ -261,6 +261,57 @@ def extract_multi_choice(text: Any) -> set:
     return set()
 
 
+def _normalize_set_item(item: Any) -> str:
+    s = unicodedata.normalize("NFKC", str(item)).strip()
+    s = re.sub(r"^\s*(?:[-*•]+|\(?\d+[\).\、]|[A-Za-z][\).\、])\s*", "", s)
+    s = s.strip(" \t\r\n\"'`“”‘’[](){}<>《》.,;:!?，。；：！？、")
+    return normalize_text(s)
+
+
+def extract_answer_set(text: Any) -> Set[str]:
+    """
+    Extract an open-ended answer set from free text.
+
+    Unlike extract_multi_choice(), this is for list-style QA/entity answers,
+    e.g. "Beijing, Shanghai" or "1. Beijing\n2. Shanghai".
+    """
+    if text is None:
+        return set()
+
+    if isinstance(text, (list, tuple, set)):
+        result: Set[str] = set()
+        for item in text:
+            result.update(extract_answer_set(item))
+        return result
+    else:
+        s = str(text).strip()
+        if not s:
+            return set()
+
+        try:
+            parsed = json.loads(s)
+            if isinstance(parsed, list):
+                items = parsed
+            else:
+                items = [s]
+        except Exception:
+            marker_match = re.search(
+                r"(?:final answer|answer|答案)\s*[:：]\s*(.+)$",
+                s,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+            if marker_match:
+                s = marker_match.group(1).strip()
+            items = re.split(r"[\n\r,，;；、|]+", s)
+
+    result: Set[str] = set()
+    for item in items:
+        norm = _normalize_set_item(item)
+        if norm:
+            result.add(norm)
+    return result
+
+
 # -------------------------------------------------------------------------
 # Ported from DataFlow (dataflow/utils/reasoning/AnswerExtraction.py)
 # -------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ scikit-learn>=1.3.0
 scipy>=1.11.0
 rouge-score>=0.1.2
 sacrebleu>=2.3.0
+sqlglot>=25.0.0
 
 # --- LLM Client & Serving ---
 openai>=1.0.0


### PR DESCRIPTION
## Summary

Add common metrics for LLM evaluation:

- `jaccard_similarity`
- `set_f1`
- `json_validity`
- `empty_or_whitespace_rate`
- `garbled_text_rate`
- `sql_parse_validity`

Also register metric metadata and add the `sqlglot` dependency for SQL parsing.